### PR TITLE
Better handle socket disconnect update limit targets

### DIFF
--- a/TdInterface/MainForm.Designer.cs
+++ b/TdInterface/MainForm.Designer.cs
@@ -69,6 +69,8 @@ namespace TdInterface
             this.checkBox1 = new System.Windows.Forms.CheckBox();
             this.txtHeartBeat = new System.Windows.Forms.TextBox();
             this.label8 = new System.Windows.Forms.Label();
+            this.txtConnectionStatus = new System.Windows.Forms.TextBox();
+            this.lblConnectionStatus = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.menuStrip1.SuspendLayout();
@@ -93,7 +95,7 @@ namespace TdInterface
             this.txtSymbol.Location = new System.Drawing.Point(42, 117);
             this.txtSymbol.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.txtSymbol.Name = "txtSymbol";
-            this.txtSymbol.Size = new System.Drawing.Size(100, 31);
+            this.txtSymbol.Size = new System.Drawing.Size(100, 27);
             this.txtSymbol.TabIndex = 1;
             this.txtSymbol.Leave += new System.EventHandler(this.txtSymbol_Leave);
             // 
@@ -102,7 +104,7 @@ namespace TdInterface
             this.lblSymbol.AutoSize = true;
             this.lblSymbol.Location = new System.Drawing.Point(42, 93);
             this.lblSymbol.Name = "lblSymbol";
-            this.lblSymbol.Size = new System.Drawing.Size(72, 25);
+            this.lblSymbol.Size = new System.Drawing.Size(59, 20);
             this.lblSymbol.TabIndex = 4;
             this.lblSymbol.Text = "Symbol";
             // 
@@ -111,7 +113,7 @@ namespace TdInterface
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(42, 50);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(44, 25);
+            this.label1.Size = new System.Drawing.Size(35, 20);
             this.label1.TabIndex = 6;
             this.label1.Text = "Risk";
             // 
@@ -120,7 +122,7 @@ namespace TdInterface
             this.txtRisk.Location = new System.Drawing.Point(104, 43);
             this.txtRisk.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.txtRisk.Name = "txtRisk";
-            this.txtRisk.Size = new System.Drawing.Size(100, 31);
+            this.txtRisk.Size = new System.Drawing.Size(100, 27);
             this.txtRisk.TabIndex = 7;
             this.txtRisk.TabStop = false;
             this.txtRisk.Text = "5";
@@ -145,7 +147,7 @@ namespace TdInterface
             this.txtLastPrice.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.txtLastPrice.Name = "txtLastPrice";
             this.txtLastPrice.ReadOnly = true;
-            this.txtLastPrice.Size = new System.Drawing.Size(100, 31);
+            this.txtLastPrice.Size = new System.Drawing.Size(100, 27);
             this.txtLastPrice.TabIndex = 9;
             this.txtLastPrice.TabStop = false;
             // 
@@ -154,7 +156,7 @@ namespace TdInterface
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(42, 235);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(49, 25);
+            this.label2.Size = new System.Drawing.Size(40, 20);
             this.label2.TabIndex = 10;
             this.label2.Text = "Stop";
             // 
@@ -163,7 +165,7 @@ namespace TdInterface
             this.txtStop.Location = new System.Drawing.Point(116, 228);
             this.txtStop.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.txtStop.Name = "txtStop";
-            this.txtStop.Size = new System.Drawing.Size(100, 31);
+            this.txtStop.Size = new System.Drawing.Size(100, 27);
             this.txtStop.TabIndex = 3;
             this.txtStop.TextChanged += new System.EventHandler(this.txtStop_TextChanged);
             // 
@@ -309,7 +311,7 @@ namespace TdInterface
             this.txtAveragePrice.Location = new System.Drawing.Point(153, 311);
             this.txtAveragePrice.Name = "txtAveragePrice";
             this.txtAveragePrice.ReadOnly = true;
-            this.txtAveragePrice.Size = new System.Drawing.Size(125, 31);
+            this.txtAveragePrice.Size = new System.Drawing.Size(125, 27);
             this.txtAveragePrice.TabIndex = 15;
             this.txtAveragePrice.TabStop = false;
             // 
@@ -318,7 +320,7 @@ namespace TdInterface
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(42, 318);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(86, 25);
+            this.label3.Size = new System.Drawing.Size(71, 20);
             this.label3.TabIndex = 16;
             this.label3.Text = "Avg Price";
             // 
@@ -327,7 +329,7 @@ namespace TdInterface
             this.txtShares.Location = new System.Drawing.Point(153, 353);
             this.txtShares.Name = "txtShares";
             this.txtShares.ReadOnly = true;
-            this.txtShares.Size = new System.Drawing.Size(125, 31);
+            this.txtShares.Size = new System.Drawing.Size(125, 27);
             this.txtShares.TabIndex = 17;
             this.txtShares.TabStop = false;
             // 
@@ -336,7 +338,7 @@ namespace TdInterface
             this.lblShares.AutoSize = true;
             this.lblShares.Location = new System.Drawing.Point(40, 360);
             this.lblShares.Name = "lblShares";
-            this.lblShares.Size = new System.Drawing.Size(64, 25);
+            this.lblShares.Size = new System.Drawing.Size(52, 20);
             this.lblShares.TabIndex = 18;
             this.lblShares.Text = "Shares";
             // 
@@ -345,7 +347,7 @@ namespace TdInterface
             this.label4.AutoSize = true;
             this.label4.Location = new System.Drawing.Point(181, 93);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(43, 25);
+            this.label4.Size = new System.Drawing.Size(35, 20);
             this.label4.TabIndex = 21;
             this.label4.Text = "Last";
             // 
@@ -354,7 +356,7 @@ namespace TdInterface
             this.label5.AutoSize = true;
             this.label5.Location = new System.Drawing.Point(317, 93);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(37, 25);
+            this.label5.Size = new System.Drawing.Size(31, 20);
             this.label5.TabIndex = 23;
             this.label5.Text = "Bid";
             // 
@@ -364,7 +366,7 @@ namespace TdInterface
             this.txtBid.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.txtBid.Name = "txtBid";
             this.txtBid.ReadOnly = true;
-            this.txtBid.Size = new System.Drawing.Size(100, 31);
+            this.txtBid.Size = new System.Drawing.Size(100, 27);
             this.txtBid.TabIndex = 22;
             this.txtBid.TabStop = false;
             // 
@@ -373,7 +375,7 @@ namespace TdInterface
             this.label6.AutoSize = true;
             this.label6.Location = new System.Drawing.Point(461, 93);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(41, 25);
+            this.label6.Size = new System.Drawing.Size(32, 20);
             this.label6.TabIndex = 25;
             this.label6.Text = "Ask";
             // 
@@ -383,7 +385,7 @@ namespace TdInterface
             this.txtAsk.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.txtAsk.Name = "txtAsk";
             this.txtAsk.ReadOnly = true;
-            this.txtAsk.Size = new System.Drawing.Size(100, 31);
+            this.txtAsk.Size = new System.Drawing.Size(100, 27);
             this.txtAsk.TabIndex = 24;
             this.txtAsk.TabStop = false;
             // 
@@ -392,7 +394,7 @@ namespace TdInterface
             this.label7.AutoSize = true;
             this.label7.Location = new System.Drawing.Point(42, 182);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(50, 25);
+            this.label7.Size = new System.Drawing.Size(42, 20);
             this.label7.TabIndex = 26;
             this.label7.Text = "Limit";
             // 
@@ -400,7 +402,7 @@ namespace TdInterface
             // 
             this.txtLimit.Location = new System.Drawing.Point(116, 175);
             this.txtLimit.Name = "txtLimit";
-            this.txtLimit.Size = new System.Drawing.Size(104, 31);
+            this.txtLimit.Size = new System.Drawing.Size(104, 27);
             this.txtLimit.TabIndex = 2;
             // 
             // menuStrip1
@@ -410,7 +412,7 @@ namespace TdInterface
             this.optionsToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(1230, 33);
+            this.menuStrip1.Size = new System.Drawing.Size(1230, 28);
             this.menuStrip1.TabIndex = 27;
             this.menuStrip1.Text = "menuStrip1";
             // 
@@ -420,20 +422,20 @@ namespace TdInterface
             this.clearCredentialsToolStripMenuItem,
             this.saveCredentialsToolStripMenuItem});
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(92, 29);
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(75, 24);
             this.optionsToolStripMenuItem.Text = "Options";
             // 
             // clearCredentialsToolStripMenuItem
             // 
             this.clearCredentialsToolStripMenuItem.Name = "clearCredentialsToolStripMenuItem";
-            this.clearCredentialsToolStripMenuItem.Size = new System.Drawing.Size(245, 34);
+            this.clearCredentialsToolStripMenuItem.Size = new System.Drawing.Size(204, 26);
             this.clearCredentialsToolStripMenuItem.Text = "Clear Credentials";
             this.clearCredentialsToolStripMenuItem.Click += new System.EventHandler(this.clearCredentialsToolStripMenuItem_Click);
             // 
             // saveCredentialsToolStripMenuItem
             // 
             this.saveCredentialsToolStripMenuItem.Name = "saveCredentialsToolStripMenuItem";
-            this.saveCredentialsToolStripMenuItem.Size = new System.Drawing.Size(245, 34);
+            this.saveCredentialsToolStripMenuItem.Size = new System.Drawing.Size(204, 26);
             this.saveCredentialsToolStripMenuItem.Text = "Save Credentials";
             this.saveCredentialsToolStripMenuItem.Click += new System.EventHandler(this.saveCredentialsToolStripMenuItem_Click);
             // 
@@ -442,7 +444,7 @@ namespace TdInterface
             this.checkBox1.AutoSize = true;
             this.checkBox1.Location = new System.Drawing.Point(229, 45);
             this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(161, 29);
+            this.checkBox1.Size = new System.Drawing.Size(136, 24);
             this.checkBox1.TabIndex = 28;
             this.checkBox1.Text = "Training Wheels";
             this.checkBox1.UseVisualStyleBackColor = true;
@@ -450,25 +452,45 @@ namespace TdInterface
             // 
             // txtHeartBeat
             // 
-            this.txtHeartBeat.Location = new System.Drawing.Point(367, 622);
+            this.txtHeartBeat.Location = new System.Drawing.Point(514, 200);
             this.txtHeartBeat.Name = "txtHeartBeat";
             this.txtHeartBeat.ReadOnly = true;
-            this.txtHeartBeat.Size = new System.Drawing.Size(270, 31);
+            this.txtHeartBeat.Size = new System.Drawing.Size(270, 27);
             this.txtHeartBeat.TabIndex = 29;
             this.txtHeartBeat.TabStop = false;
             // 
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(257, 624);
+            this.label8.Location = new System.Drawing.Point(404, 202);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(89, 25);
+            this.label8.Size = new System.Drawing.Size(76, 20);
             this.label8.TabIndex = 30;
             this.label8.Text = "HeartBeat";
+            // 
+            // txtConnectionStatus
+            // 
+            this.txtConnectionStatus.Location = new System.Drawing.Point(512, 233);
+            this.txtConnectionStatus.Name = "txtConnectionStatus";
+            this.txtConnectionStatus.ReadOnly = true;
+            this.txtConnectionStatus.Size = new System.Drawing.Size(278, 27);
+            this.txtConnectionStatus.TabIndex = 31;
+            this.txtConnectionStatus.TabStop = false;
+            // 
+            // lblConnectionStatus
+            // 
+            this.lblConnectionStatus.AutoSize = true;
+            this.lblConnectionStatus.Location = new System.Drawing.Point(352, 240);
+            this.lblConnectionStatus.Name = "lblConnectionStatus";
+            this.lblConnectionStatus.Size = new System.Drawing.Size(128, 20);
+            this.lblConnectionStatus.TabIndex = 32;
+            this.lblConnectionStatus.Text = "Connection Status";
             // 
             // MainForm
             // 
             this.ClientSize = new System.Drawing.Size(1230, 684);
+            this.Controls.Add(this.lblConnectionStatus);
+            this.Controls.Add(this.txtConnectionStatus);
             this.Controls.Add(this.label8);
             this.Controls.Add(this.txtHeartBeat);
             this.Controls.Add(this.checkBox1);
@@ -553,6 +575,8 @@ namespace TdInterface
         private System.Windows.Forms.CheckBox checkBox1;
         private System.Windows.Forms.TextBox txtHeartBeat;
         private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.TextBox txtConnectionStatus;
+        private System.Windows.Forms.Label lblConnectionStatus;
     }
 }
 

--- a/TdInterface/MainForm.cs
+++ b/TdInterface/MainForm.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -85,7 +86,7 @@ namespace TdInterface
 
                 var orderType = "MARKET";
                 var symbol = txtSymbol.Text;
-                var instruction = "SELL";
+                var instruction = OrderHelper.SELL_SHORT;
                 var triggerLimit = double.Parse("0.0");
 
                 await GenericTriggerOco(stockQuote, orderType, symbol, instruction, triggerLimit);
@@ -102,14 +103,9 @@ namespace TdInterface
             var trainingWheels = checkBox1.Checked;
             var maxRisk = txtRisk.Text;
 
-            /*
-            var bidOrAskPrice = instruction.Equals("SELL") ? stockQuote.bidPrice : stockQuote.askPrice;
-            var riskPerShare = instruction.Equals("SELL") ? stopPrice - bidOrAskPrice : bidOrAskPrice - stopPrice;
-            var firstTargetlimtPrice = instruction.Equals("SELL") ? bidOrAskPrice - riskPerShare : bidOrAskPrice + riskPerShare;
-            */
             var bidOrAskPrice = stockQuote.lastPrice;
-            var riskPerShare = instruction.Equals("SELL") ? stopPrice - bidOrAskPrice : bidOrAskPrice - stopPrice;
-            var firstTargetlimtPrice = instruction.Equals("SELL") ? bidOrAskPrice - riskPerShare : bidOrAskPrice + riskPerShare;
+            var riskPerShare = instruction.Equals(OrderHelper.SELL_SHORT) ? stopPrice - bidOrAskPrice : bidOrAskPrice - stopPrice;
+            var firstTargetlimtPrice = instruction.Equals(OrderHelper.SELL_SHORT) ? bidOrAskPrice - riskPerShare : bidOrAskPrice + riskPerShare;
 
             int quantity = CalcShares(riskPerShare, maxRisk, trainingWheels);
 
@@ -118,6 +114,7 @@ namespace TdInterface
             ResetInitialOrder();
             var triggerOrder = OrderHelper.CreateTriggerOcoOrder(orderType, symbol, instruction, quantity, triggerLimit, firstTargetLimitShares, firstTargetlimtPrice, stopPrice);
             var orderKey = await TdHelper.PlaceOrder(Utility.AccessTokenContainer, Utility.UserPrincipal, triggerOrder);
+            txtLastError.Text = JsonConvert.SerializeObject(triggerOrder);
             AddInitialOrder(symbol, orderKey, triggerOrder);
 
         }
@@ -158,7 +155,7 @@ namespace TdInterface
                 var stockQuote = _stockQuote;
                 var orderType = "LIMIT";
                 var symbol = txtSymbol.Text;
-                var instruction = "SELL";
+                var instruction = OrderHelper.SELL_SHORT;
                 var triggerLimit = double.Parse(txtLimit.Text);
 
                 await GenericTriggerOco(stockQuote, orderType, symbol, instruction, triggerLimit);
@@ -178,7 +175,7 @@ namespace TdInterface
                 var stockQuote = _stockQuote;
                 var orderType = "MARKET";
                 var symbol = txtSymbol.Text;
-                var instruction = "BUY";
+                var instruction = OrderHelper.BUY;
                 var triggerLimit = double.Parse("0.0");
 
                 await GenericTriggerOco(stockQuote, orderType, symbol, instruction, triggerLimit);
@@ -196,7 +193,7 @@ namespace TdInterface
                 var stockQuote = _stockQuote;
                 var orderType = "LIMIT";
                 var symbol = txtSymbol.Text;
-                var instruction = "BUY";
+                var instruction = OrderHelper.BUY;
                 var triggerLimit = double.Parse(txtLimit.Text);
 
                 await GenericTriggerOco(stockQuote, orderType, symbol, instruction, triggerLimit);
@@ -228,12 +225,12 @@ namespace TdInterface
                 int quantity = 0;
                 if (_activePosition.longQuantity > 0)
                 {
-                    stopInstruction = "SELL";
+                    stopInstruction = OrderHelper.SELL;
                     quantity = (int)_activePosition.longQuantity;
                 }
                 else if (_activePosition.shortQuantity > 0)
                 {
-                    stopInstruction = "BUY";
+                    stopInstruction = OrderHelper.BUY_TO_COVER;
                     quantity = (int)_activePosition.shortQuantity;
                 }
                 else
@@ -312,11 +309,11 @@ namespace TdInterface
             var exitInstruction = "";
             if (position.longQuantity > 0)
             {
-                exitInstruction = "SELL";
+                exitInstruction = OrderHelper.SELL;
             }
             else if (position.shortQuantity > 0)
             {
-                exitInstruction = "BUY";
+                exitInstruction = OrderHelper.BUY_TO_COVER;
             }
             else
             {

--- a/TdInterface/OrderHelper.cs
+++ b/TdInterface/OrderHelper.cs
@@ -7,9 +7,14 @@ namespace TdInterface
 {
     public class OrderHelper
     {
+        public const string BUY = "BUY";
+        public const string BUY_TO_COVER = "BUY_TO_COVER";
+        public const string SELL = "SELL";
+        public const string SELL_SHORT = "SELL_SHORT";
+
         public static Order CreateTriggerOcoOrder(string triggerOrderType, string symbol, string instruction, int quantity, double triggerLimit, int firstTargetLimitQuantity, double firstTargetLimitPrice, double stopPrice)
         {
-            var exitInstruction = instruction == "BUY" ? "SELL" : "BUY";
+            var exitInstruction = instruction == BUY ? SELL : BUY_TO_COVER;
 
             Order triggerOrder = null;
 


### PR DESCRIPTION
Updated to handle socket disconnects more gracefully.
Changed the way targets and shares are calculated for Limit orders.  Based off limit, not last.
Changed the order instructions, to work with accounts that did not have Advanced Features turned on.