### PR TITLE
Handling Enter on Symbol Field

### DIFF
--- a/TdInterface/Forms/MainForm.Designer.cs
+++ b/TdInterface/Forms/MainForm.Designer.cs
@@ -109,11 +109,13 @@ namespace TdInterface
             // 
             // txtSymbol
             // 
+            this.txtSymbol.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
             this.txtSymbol.Location = new System.Drawing.Point(14, 28);
             this.txtSymbol.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.txtSymbol.Name = "txtSymbol";
             this.txtSymbol.Size = new System.Drawing.Size(85, 23);
             this.txtSymbol.TabIndex = 0;
+            this.txtSymbol.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtSymbol_KeyPress);
             this.txtSymbol.Leave += new System.EventHandler(this.txtSymbol_Leave);
             // 
             // lblSymbol

--- a/TdInterface/Forms/MainForm.cs
+++ b/TdInterface/Forms/MainForm.cs
@@ -1002,6 +1002,7 @@ namespace TdInterface
                     txtStopToClose.Text = String.Empty;
                     txtOneToOne.Text = String.Empty;
                     txtRValue.Text = String.Empty;
+                    txtStop.Focus();
                     await SetPosition();
                 }
             }
@@ -1138,5 +1139,14 @@ namespace TdInterface
 
 
         #endregion
+
+        private void txtSymbol_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            if (e.KeyChar == (char)Keys.Return)
+            {
+                txtSymbol_Leave(sender,e);
+                e.Handled = true;
+            }
+        }
     }
 }

--- a/TdInterface/Forms/MainForm.cs
+++ b/TdInterface/Forms/MainForm.cs
@@ -1002,7 +1002,6 @@ namespace TdInterface
                     txtStopToClose.Text = String.Empty;
                     txtOneToOne.Text = String.Empty;
                     txtRValue.Text = String.Empty;
-                    txtStop.Focus();
                     await SetPosition();
                 }
             }
@@ -1146,6 +1145,7 @@ namespace TdInterface
             {
                 txtSymbol_Leave(sender,e);
                 e.Handled = true;
+                txtStop.Focus();
             }
         }
     }


### PR DESCRIPTION
Handle Enter on the symbol field, but simply calling same function tab would cause on this field, and handling the enter key to avoid the annoying 'error' sound.

Also updated the field to be all caps, to align style with other experiences we are used to (TradingView, ToS, etc.)