### PR TITLE
Only clear the text boxes, etc. Once the symbol changes.

### DIFF
--- a/TdInterface/Forms/MainForm.cs
+++ b/TdInterface/Forms/MainForm.cs
@@ -21,6 +21,7 @@ namespace TdInterface
         private IStreamer _streamer;
         private StockQuote _stockQuote = new StockQuote();
         private TdHelper _tdHelper= new TdHelper();
+        private string curSymbol = String.Empty;
 
       
         // Made Public for testing.
@@ -991,8 +992,9 @@ namespace TdInterface
         {
             try
             {
-                if (txtSymbol.Text != String.Empty)
+                if (txtSymbol.Text != String.Empty && !txtSymbol.Text.Equals(curSymbol, StringComparison.OrdinalIgnoreCase))
                 {
+                    curSymbol = txtSymbol.Text;
                     _streamer.SubscribeQuote(Utility.UserPrincipal, txtSymbol.Text.ToUpper());
                     //_streamer.SubscribeChartData(Utility.UserPrincipal, txtSymbol.Text.ToUpper());
                     //await UpdatePriceHistory();


### PR DESCRIPTION
Quick fix for not clearing the text box if symbol box gets focus, and the user leaves it without changing the symbol... 