### PR TITLE
Fixing R value being incorrect sign and Max Risk setting exception

### DIFF
--- a/TdInterface/Forms/MainForm.cs
+++ b/TdInterface/Forms/MainForm.cs
@@ -553,6 +553,7 @@ namespace TdInterface
 
                     float risk = Math.Abs(avgPrice - initialStop);
                     float reward = (float)_stockQuote.lastPrice - avgPrice;
+                    reward = reward * (_activePosition.shortQuantity > 0 ? -1 : 1);
 
                     var rValue = reward / risk;
                     SafeUpdateTextBox(txtRValue, rValue.ToString("0.00"));

--- a/TdInterface/Forms/UserOptionsForm.cs
+++ b/TdInterface/Forms/UserOptionsForm.cs
@@ -24,7 +24,7 @@ namespace TdInterface
         private void btnSave_Click(object sender, EventArgs e)
         {
             _settings.TradeShares = chkTrainingWheels.Checked;
-            _settings.MaxRisk = Decimal.Parse(txtMaxRisk.Text);
+            _settings.MaxRisk = string.IsNullOrEmpty(txtMaxRisk.Text) ? 0 : Decimal.Parse(txtMaxRisk.Text);
             _settings.MaxShares = int.Parse(txtMaxShares.Text);
             _settings.UseBidAskOcoCalc = chkUseBidAskOcoCalc.Checked;
             _settings.DisableFirstTargetProfitDefault = chkDisableFirstTarget.Checked;


### PR DESCRIPTION
RValue was showing wrong sign based in short positions.
Exception is being thrown in settings if you do not set a max risk but try to save other settings.