### PR TITLE
Remove request for bid size from TDA API

### DIFF
--- a/TdInterface/Tda/TDStreamer.cs
+++ b/TdInterface/Tda/TDStreamer.cs
@@ -347,7 +347,7 @@ namespace TdInterface.Tda
                 parameters = new StreamerSettings.Parameters
                 {
                     keys = symbols,
-                    fields = "0,1,2,3,4"
+                    fields = "0,1,2,3"
                 }
             };
             _reqs.Add(quoteRequest);


### PR DESCRIPTION
Removing ask for Bid Size from API to reduce responses with 0 in all three values, causing 1:1 to be negative and change incorrectly.

Fixes #99 and #72