### PR TITLE
Fix Negative OneToOne

### DIFF
--- a/TdInterface/Forms/MainForm.cs
+++ b/TdInterface/Forms/MainForm.cs
@@ -659,9 +659,9 @@ namespace TdInterface
                         }
                         else
                         {
-                            oneToOne = stockQuote.lastPrice - (stop - _stockQuote.lastPrice);
+                            oneToOne = _stockQuote.lastPrice - (stop - _stockQuote.lastPrice);
                         }
-                        SafeUpdateTextBox(txtOneToOne, oneToOne.ToString("0.00"));
+                       SafeUpdateTextBox(txtOneToOne, oneToOne.ToString("0.00"));
                     }
                 }
             }

--- a/TdInterface/Tda/TDStreamer.cs
+++ b/TdInterface/Tda/TDStreamer.cs
@@ -248,7 +248,7 @@ namespace TdInterface.Tda
 
                                 var stockQuote = new StockQuote(quoteJson);
                                 _stockQuoteRecievedSubject.OnNext(stockQuote);
-                                Debug.WriteLine(JsonConvert.SerializeObject(stockQuote));
+                                Debug.WriteLine("TDStreamer:" + JsonConvert.SerializeObject(stockQuote));
                             }
                         }
                         else if (service == "LEVELONE_FUTURES")


### PR DESCRIPTION
When not in a position, code was using raw stock quote values in one case instead of the updated stock quote object that handles 0.0 values...

Fixes #99 and #72 