### PR TITLE
Fixing some exceptions and limit on securities account checks

### DIFF
--- a/TdInterface/Forms/MainForm.Designer.cs
+++ b/TdInterface/Forms/MainForm.Designer.cs
@@ -484,7 +484,7 @@ namespace TdInterface
             // timerGetSecuritiesAccount
             // 
             this.timerGetSecuritiesAccount.Enabled = true;
-            this.timerGetSecuritiesAccount.Interval = 10000;
+            this.timerGetSecuritiesAccount.Interval = 20000;
             this.timerGetSecuritiesAccount.Tick += new System.EventHandler(this.timerGetSecuritiesAccount_Tick);
             // 
             // label10

--- a/TdInterface/Forms/MainForm.cs
+++ b/TdInterface/Forms/MainForm.cs
@@ -342,7 +342,7 @@ namespace TdInterface
         {
             try
             {
-                if (sender is Button)
+                if (sender is Button && _activePosition != null)
                 {
                     Button btn = (Button)sender;
 

--- a/TdInterface/Forms/MainForm.cs
+++ b/TdInterface/Forms/MainForm.cs
@@ -668,7 +668,7 @@ namespace TdInterface
                 await SetPosition();
                 _securitiesaccount = await GetSecuritiesaccountAsync();
 
-                if (typeof(TdHelper) == _tradeHelper.GetType())
+                if (typeof(TdHelper) == _tradeHelper.GetType() && _securitiesaccount != null)
                 {
                     txtPnL.Text = _securitiesaccount.DailyPnL.ToString("#.##");
                 }
@@ -699,7 +699,7 @@ namespace TdInterface
         {
             try
             {
-                _securitiesaccount= await GetSecuritiesaccountAsync();
+                _securitiesaccount = await GetSecuritiesaccountAsync();
 
                 var symbol = orderEntryRequestMessage.Order.Security.Symbol;
                 Debug.WriteLine($"HandleOrderReceived: symbol {symbol}");
@@ -709,7 +709,7 @@ namespace TdInterface
                 {
                     Debug.WriteLine("HandleOrderReceived: Found Initial Order by symbol");
                     //We have an initial order lets find the limit and save it off
-                    if (_initialOrders[symbol].Contains(orderEntryRequestMessage.Order.OrderKey))
+                    if (_initialOrders[symbol].Contains(orderEntryRequestMessage.Order.OrderKey) && _securitiesaccount != null)
                     {
                         Debug.WriteLine("HandleOrderReceived: Found Initial Order by OrderKey");
                         var triggerOrder = _securitiesaccount.orderStrategies.Where(o => ulong.Parse(o.orderId) == orderEntryRequestMessage.Order.OrderKey).FirstOrDefault();
@@ -770,34 +770,36 @@ namespace TdInterface
 
                             _securitiesaccount = await GetSecuritiesaccountAsync();
 
-
-                            var triggerOrder = _securitiesaccount.orderStrategies.Where(o => ulong.Parse(o.orderId) == orderFillMessage.Order.OrderKey).FirstOrDefault();
-                            //Get Trigger order by key and from there look at child strats to find the limit,  orders are not flat like I thought.
-                            //So the Trigger has an OCO that has the limit and stop.
-                            //
-                            Order lmitOrder = null;
-
-                            if (triggerOrder.childOrderStrategies[0].childOrderStrategies != null)
+                            if (_securitiesaccount != null)
                             {
-                                lmitOrder = triggerOrder.childOrderStrategies[0].childOrderStrategies.Where(o => (o.status == "QUEUED" || o.status == "WORKING" || o.status == "PENDING_ACTIVATION" || o.status == "AWAITING_PARENT_ORDER") && o.orderLegCollection[0].instrument.symbol == txtSymbol.Text.ToUpper() && o.orderType == "LIMIT").FirstOrDefault();
-                            }
+                                var triggerOrder = _securitiesaccount.orderStrategies.Where(o => ulong.Parse(o.orderId) == orderFillMessage.Order.OrderKey).FirstOrDefault();
+                                //Get Trigger order by key and from there look at child strats to find the limit,  orders are not flat like I thought.
+                                //So the Trigger has an OCO that has the limit and stop.
+                                //
+                                Order lmitOrder = null;
 
-                            if (lmitOrder != null)
-                            {
-                                Debug.WriteLine($"Found Limit Order {JsonConvert.SerializeObject(lmitOrder)} ");
-                                var stop = float.Parse(txtStop.Text);
-                                var avgPrice = _activePosition.averagePrice;
-                                var risk = Math.Abs(avgPrice - stop);
+                                if (triggerOrder.childOrderStrategies[0].childOrderStrategies != null)
+                                {
+                                    lmitOrder = triggerOrder.childOrderStrategies[0].childOrderStrategies.Where(o => (o.status == "QUEUED" || o.status == "WORKING" || o.status == "PENDING_ACTIVATION" || o.status == "AWAITING_PARENT_ORDER") && o.orderLegCollection[0].instrument.symbol == txtSymbol.Text.ToUpper() && o.orderType == "LIMIT").FirstOrDefault();
+                                }
+
+                                if (lmitOrder != null)
+                                {
+                                    Debug.WriteLine($"Found Limit Order {JsonConvert.SerializeObject(lmitOrder)} ");
+                                    var stop = float.Parse(txtStop.Text);
+                                    var avgPrice = _activePosition.averagePrice;
+                                    var risk = Math.Abs(avgPrice - stop);
 
 
-                                string exitInstruction = GetExitInstruction(_activePosition);
+                                    string exitInstruction = GetExitInstruction(_activePosition);
 
-                                var firstTargetlimtPrice = exitInstruction == "SELL" ? avgPrice + risk : avgPrice - risk;
+                                    var firstTargetlimtPrice = exitInstruction == "SELL" ? avgPrice + risk : avgPrice - risk;
 
-                                Debug.WriteLine($"stop: {stop} ; avgPrice: {avgPrice} ; risk: {risk} ; exitInsturction: {exitInstruction} ; firstTargetLimitPrice: {firstTargetlimtPrice}");
+                                    Debug.WriteLine($"stop: {stop} ; avgPrice: {avgPrice} ; risk: {risk} ; exitInsturction: {exitInstruction} ; firstTargetLimitPrice: {firstTargetlimtPrice}");
 
-                                var newLimitOrder = TDAOrderHelper.CreateLimitOrder(exitInstruction, symbol, Convert.ToInt32(Math.Round(lmitOrder.orderLegCollection[0].quantity)), firstTargetlimtPrice);
-                                await _tradeHelper.ReplaceOrder(Utility.AccessTokenContainer, _accountId, lmitOrder.orderId, newLimitOrder);
+                                    var newLimitOrder = TDAOrderHelper.CreateLimitOrder(exitInstruction, symbol, Convert.ToInt32(Math.Round(lmitOrder.orderLegCollection[0].quantity)), firstTargetlimtPrice);
+                                    await _tradeHelper.ReplaceOrder(Utility.AccessTokenContainer, _accountId, lmitOrder.orderId, newLimitOrder);
+                                }
                             }
                         }
                     }
@@ -924,21 +926,23 @@ namespace TdInterface
             {
                 _securitiesaccount = await GetSecuritiesaccountAsync();
 
+                if (_securitiesaccount != null)
+                {
+                    try
+                    {
+                        SafeUpdateTextBox(txtPnL, _securitiesaccount.DailyPnL.ToString("#.##"));
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine("Can't Update PnL");
+                        Debug.WriteLine(ex.Message);
+                        Debug.WriteLine(ex.StackTrace);
+                    }
 
-                try
-                {
-                    SafeUpdateTextBox(txtPnL, _securitiesaccount.DailyPnL.ToString("#.##"));
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine("Can't Update PnL");
-                    Debug.WriteLine(ex.Message);
-                    Debug.WriteLine(ex.StackTrace);
-                }
-
-                if (_securitiesaccount.positions != null)
-                {
-                    position = _securitiesaccount.positions.Where(p => p != null && p.instrument.symbol == symbol).FirstOrDefault();
+                    if (_securitiesaccount.positions != null)
+                    {
+                        position = _securitiesaccount.positions.Where(p => p != null && p.instrument.symbol == symbol).FirstOrDefault();
+                    }
                 }
             }
             catch (Exception ex)
@@ -1198,7 +1202,7 @@ namespace TdInterface
 
             try
             {
-                if (_tradeHelper.GetType() == typeof(TdHelper))
+                if (_tradeHelper.GetType() == typeof(TdHelper) && _securitiesaccount != null)
                 {
                     SafeUpdateTextBox(txtPnL, _securitiesaccount.DailyPnL.ToString("#.##"));
                 }

--- a/TdInterface/Tda/TdHelper.cs
+++ b/TdInterface/Tda/TdHelper.cs
@@ -128,6 +128,12 @@ namespace TdInterface.Tda
             var securitiesaccount = Securitiesaccount.ParseJson(await response.Content.ReadAsStringAsync());
             Debug.WriteLine(JsonConvert.SerializeObject(securitiesaccount));
 
+            if (securitiesaccount == null)
+            {
+                Debug.WriteLine("Securities Account is null!");
+                Debug.WriteLine($"GetAccount Response {response.StatusCode}: {response.Content}");
+            }
+
             return securitiesaccount;
         }
 
@@ -333,16 +339,24 @@ namespace TdInterface.Tda
         public async Task CancelAll(AccessTokenContainer accessTokenContainer, string accountId, string symbol)
         {
             var securitiesaccount = await this.GetAccount(Utility.AccessTokenContainer, accountId);
-            var openOrders = securitiesaccount.FlatOrders.Where(o => (o.status == "QUEUED" || o.status == "WORKING" || o.status == "PENDING_ACTIVATION") && o.orderLegCollection[0].instrument.symbol.Equals(symbol, StringComparison.InvariantCultureIgnoreCase));
 
-            var tasks = new List<Task>();
-            foreach (var order in openOrders)
+            if (securitiesaccount != null)
             {
-                var task = this.CancelOrder(Utility.AccessTokenContainer, accountId, order);
-                tasks.Add(task);
-            }
+                var openOrders = securitiesaccount.FlatOrders.Where(o => (o.status == "QUEUED" || o.status == "WORKING" || o.status == "PENDING_ACTIVATION") && o.orderLegCollection[0].instrument.symbol.Equals(symbol, StringComparison.InvariantCultureIgnoreCase));
 
-            await Task.WhenAll(tasks).ConfigureAwait(true);
+                var tasks = new List<Task>();
+                foreach (var order in openOrders)
+                {
+                    var task = this.CancelOrder(Utility.AccessTokenContainer, accountId, order);
+                    tasks.Add(task);
+                }
+
+                await Task.WhenAll(tasks).ConfigureAwait(true);
+            }
+            else
+            {
+                Debug.WriteLine("CancelAll - securitiesAccount is null");
+            }
         }
     }
 }


### PR DESCRIPTION
App is being throttled, changed security account checking to every 20 seconds instead of 10.

Fixed several null exceptions around securities account, and one for activePosition.