### PR TITLE
Master form code cleanup

### DIFF
--- a/TdInterface/Forms/AboutForm.cs
+++ b/TdInterface/Forms/AboutForm.cs
@@ -10,7 +10,7 @@ namespace TdInterface.Forms
         public AboutForm()
         {
             InitializeComponent();
-            lblVersion.Text = $"Version: {Program.GetAppVersion()}";
+            lblVersion.Text = $"Version: {Program.AppVersion}";
         }
     }
 }

--- a/TdInterface/Forms/AccountInfoForm.cs
+++ b/TdInterface/Forms/AccountInfoForm.cs
@@ -32,7 +32,7 @@ namespace TdInterface.Forms
 
         private void AccountInfoForm_Load(object sender, EventArgs e)
         {
-            _accountInfo = new Utility().GetAccountInfo();
+            _accountInfo = Utility.GetAccountInfo();
             if (_accountInfo == null) _accountInfo = new AccountInfo();
             chkTdaEnableEquity.Checked = _accountInfo.UseTdaEquity;
             txtConsumerKey.Text = _accountInfo.TdaConsumerKey;

--- a/TdInterface/Forms/MainForm.cs
+++ b/TdInterface/Forms/MainForm.cs
@@ -81,7 +81,7 @@ namespace TdInterface
             // Handle always on top setting
             this.TopMost = settings.AlwaysOnTop;
 
-            lblVersion.Text = $"v {Program.GetAppVersion()}";
+            lblVersion.Text = $"v {Program.AppVersion}";
         }
 
 

--- a/TdInterface/Forms/MainForm.cs
+++ b/TdInterface/Forms/MainForm.cs
@@ -921,8 +921,6 @@ namespace TdInterface
                 {
                     curSymbol = txtSymbol.Text;
                     _streamer.SubscribeQuote(txtSymbol.Text.ToUpper());
-                    //_streamer.SubscribeChartData(Utility.UserPrincipal, txtSymbol.Text.ToUpper());
-                    //await UpdatePriceHistory();
                     txtStop.Text = String.Empty;
                     txtLimit.Text = String.Empty;
                     txtStopToClose.Text = String.Empty;

--- a/TdInterface/Forms/MasterForm.Designer.cs
+++ b/TdInterface/Forms/MasterForm.Designer.cs
@@ -357,7 +357,6 @@
             this.Name = "MasterForm";
             this.Text = "EZTM";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MasterForm_FormClosing);
-            this.Load += new System.EventHandler(this.MasterForm_Load);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.ResumeLayout(false);

--- a/TdInterface/Forms/MasterForm.cs
+++ b/TdInterface/Forms/MasterForm.cs
@@ -148,19 +148,6 @@ namespace TdInterface
         {
             var frm = new UserOptionsForm();
             frm.ShowDialog();
-            Program.Settings = Utility.GetSettings();
-            //ApplySettings();
-        }
-
-        private void MasterForm_Load(object sender, EventArgs e)
-        {
-            var settings = Utility.GetSettings();
-            if (settings != null)
-            {
-                settings.OneRProfitPercenatage = settings.OneRProfitPercenatage == 0 ? Program.Settings.OneRProfitPercenatage : settings.OneRProfitPercenatage;
-                Program.Settings = settings;
-            }
-
         }
 
         private static Dictionary<string, MainForm> _mainForms = new  Dictionary<string, MainForm>();

--- a/TdInterface/Forms/MasterForm.cs
+++ b/TdInterface/Forms/MasterForm.cs
@@ -23,7 +23,6 @@ namespace TdInterface
         private IStreamer _streamer;
         private string _equityAccountId;
 
-        private Settings _settings = new() { TradeShares = false, MaxRisk = 5M, MaxShares = 4, OneRProfitPercenatage = 25 };
         private TdHelper _tdHelper = new TdHelper();
         private TradeStationHelper _tradeStationHelper;
         private IHelper _tradeHelper;
@@ -149,7 +148,7 @@ namespace TdInterface
         {
             var frm = new UserOptionsForm();
             frm.ShowDialog();
-            _settings = Utility.GetSettings();
+            Program.Settings = Utility.GetSettings();
             //ApplySettings();
         }
 
@@ -158,8 +157,8 @@ namespace TdInterface
             var settings = Utility.GetSettings();
             if (settings != null)
             {
-                settings.OneRProfitPercenatage = settings.OneRProfitPercenatage == 0 ? _settings.OneRProfitPercenatage : settings.OneRProfitPercenatage;    
-                _settings = settings;
+                settings.OneRProfitPercenatage = settings.OneRProfitPercenatage == 0 ? Program.Settings.OneRProfitPercenatage : settings.OneRProfitPercenatage;
+                Program.Settings = settings;
             }
 
         }
@@ -227,13 +226,13 @@ namespace TdInterface
             {
                 if (!string.IsNullOrEmpty(name))
                 {
-                    frm = new MainForm(_streamer, _settings, name, _equityAccountId, _tradeHelper);
+                    frm = new MainForm(_streamer, name, _equityAccountId, _tradeHelper);
                     frm.Tag = name;
                     _mainForms.Add(nameAsKey, frm);
                 }
                 else
                 {
-                    frm = new MainForm(_streamer, _settings, "Enter a symbol...", _equityAccountId, _tradeHelper);
+                    frm = new MainForm(_streamer, "Enter a symbol...", _equityAccountId, _tradeHelper);
                     _mainForms.Add(nameAsKey, frm);
 
                 }

--- a/TdInterface/Forms/MasterForm.cs
+++ b/TdInterface/Forms/MasterForm.cs
@@ -58,7 +58,6 @@ namespace TdInterface
 
                 if (accountInfo.UseTdaEquity)
                 {
-                    _tdHelper.AccessTokenContainer = Utility.GetAccessTokenContainer(TdHelper.ACCESSTOKENCONTAINER);
                     if (_tdHelper.AccessTokenContainer == null || (_tdHelper.AccessTokenContainer.TokenSystem == AccessTokenContainer.EnumTokenSystem.TDA && (_tdHelper.AccessTokenContainer.IsRefreshTokenExpired || _tdHelper.AccessTokenContainer.RefreshTokenExpiresInDays < 5)))
                     {
                         Utility.SplitTdaConsumerKey(accountInfo.TdaConsumerKey, out string consumerKey, out string redirectUri);
@@ -82,17 +81,7 @@ namespace TdInterface
                     var clientid = accountInfo.TradeStationClientId;
                     var clientSecret = accountInfo.TradeStationClientSecret;
 
-
-                    if (accountInfo.TradeStationUseSimAccount)
-                    {
-                        _tradeStationHelper = new TradeStationHelper("https://sim-api.tradestation.com/", clientid, clientSecret);
-                    }
-                    else
-                    {
-                        _tradeStationHelper = new TradeStationHelper(clientid, clientSecret);
-                    }
-
-                    _tradeStationHelper.AccessTokenContainer = Utility.GetAccessTokenContainer(TradeStationHelper.ACCESSTOKENCONTAINER);
+                    _tradeStationHelper = new TradeStationHelper(clientid, clientSecret, accountInfo.TradeStationUseSimAccount);
 
                     if (_tradeStationHelper.AccessTokenContainer == null)
                     {

--- a/TdInterface/Forms/MasterForm.cs
+++ b/TdInterface/Forms/MasterForm.cs
@@ -26,7 +26,6 @@ namespace TdInterface
         private TdHelper _tdHelper = new TdHelper();
         private TradeStationHelper _tradeStationHelper;
         private IHelper _tradeHelper;
-        private Utility _utility = new Utility();
 
         public MasterForm()
         {
@@ -47,12 +46,12 @@ namespace TdInterface
             try
             {
 
-                var accountInfo = _utility.GetAccountInfo();
+                var accountInfo = Utility.GetAccountInfo();
                 if (accountInfo == null)
                 {
                     var frmAccountInfo = new AccountInfoForm();
                     frmAccountInfo.ShowDialog();
-                    accountInfo = _utility.GetAccountInfo();
+                    accountInfo = Utility.GetAccountInfo();
                 }
 
                 string loginUri = string.Empty;
@@ -122,7 +121,7 @@ namespace TdInterface
                 {
                     var frmAccountInfo = new AccountInfoForm();
                     frmAccountInfo.ShowDialog();
-                    accountInfo = _utility.GetAccountInfo();
+                    accountInfo = Utility.GetAccountInfo();
                 }
 
                 timer1.Start();

--- a/TdInterface/Forms/MasterForm.cs
+++ b/TdInterface/Forms/MasterForm.cs
@@ -24,7 +24,6 @@ namespace TdInterface
         private string _equityAccountId;
 
         private Settings _settings = new() { TradeShares = false, MaxRisk = 5M, MaxShares = 4, OneRProfitPercenatage = 25 };
-        private TextWriterTraceListener _textWriterTraceListener = null;
         private TdHelper _tdHelper = new TdHelper();
         private TradeStationHelper _tradeStationHelper;
         private IHelper _tradeHelper;
@@ -34,14 +33,6 @@ namespace TdInterface
         {
             try
             {
-                string currentPath = Directory.GetCurrentDirectory();
-                string logFolder = Path.Combine(currentPath, "logs");
-                if (!Directory.Exists(logFolder))
-                    Directory.CreateDirectory(logFolder);
-
-                _textWriterTraceListener = new TextWriterTraceListener($"{logFolder}\\{DateTime.Now.ToString("yyyyMMdd-HHmmss")}.log");
-                Trace.Listeners.Add(_textWriterTraceListener);
-
                 Debug.WriteLine("Start Master Form");
                 InitializeComponent();
 
@@ -148,7 +139,7 @@ namespace TdInterface
 
         private async void timer1_Tick(object sender, EventArgs e)
         {
-            if (_tradeStationHelper.AccessTokenContainer.ExpiresIn < 100)
+            if (_tradeHelper.AccessTokenContainer.ExpiresIn < 100)
             {
                 _ = await _tradeHelper.RefreshAccessToken();
             }
@@ -198,10 +189,7 @@ namespace TdInterface
         {
             try
             {
-                _textWriterTraceListener.Flush();
-                _textWriterTraceListener.Close();
                 if(_streamer != null) _streamer.Dispose();
-                _textWriterTraceListener.Dispose();
 
                 foreach(var frm in _mainForms)
                 {

--- a/TdInterface/Forms/UserOptionsForm.cs
+++ b/TdInterface/Forms/UserOptionsForm.cs
@@ -6,7 +6,6 @@ namespace TdInterface
 {
     public partial class UserOptionsForm : EZTMBaseForm
     {
-        public Settings _settings;
         public UserOptionsForm()
         {
             InitializeComponent();
@@ -14,52 +13,52 @@ namespace TdInterface
 
         private void btnSave_Click(object sender, EventArgs e)
         {
-            _settings.TradeShares = chkTradeShares.Checked;
-            _settings.MaxRisk = string.IsNullOrEmpty(txtMaxRisk.Text) ? 0 : decimal.Parse(txtMaxRisk.Text);
-            _settings.MaxShares = int.Parse(txtMaxShares.Text);
-            _settings.UseBidAskOcoCalc = chkUseBidAskOcoCalc.Checked;
-            _settings.DisableFirstTargetProfitDefault = chkDisableFirstTarget.Checked;
-            _settings.OneRProfitPercenatage = int.Parse(txtOneRSharePct.Text);
-            _settings.MoveLimitPriceOnFill = chkMoveLimitOnFill.Checked;
-            _settings.ReduceStopOnClose = chkReduceStopOnClose.Checked;
-            _settings.DefaultLimitOffset = string.IsNullOrEmpty(txtDefaultLimitOffset.Text) ? 0 : decimal.Parse(txtDefaultLimitOffset.Text);
-            _settings.EnableMaxLossLimit = chkMaxLossLimit.Checked;
-            _settings.MaxLossLimitInR = _settings.EnableMaxLossLimit ? decimal.Parse(txtMaxLossLimit.Text) : 0;
-            _settings.MinimumRisk = string.IsNullOrEmpty(txtMinRisk.Text) ? 0 : double.Parse(txtMinRisk.Text);
-            _settings.SendAltPrtScrOnOpen = chkSendPrtScrOnOpen.Checked;
-            _settings.ShowPnL = chkShowPnL.Checked;
-            _settings.PreventRiskExceedMaxLoss = chkPreventExceedMaxLoss.Checked;
-            _settings.AdjustRiskNotExceedMaxLoss = chkAdjustRiskForMaxLoss.Checked;
-            _settings.AlwaysOnTop = chkAlwaysOnTop.Checked;
-            _settings.CaptureScreenshotOnOpen = chkCaptureSSOnOpen.Checked;
+            Program.Settings.TradeShares = chkTradeShares.Checked;
+            Program.Settings.MaxRisk = string.IsNullOrEmpty(txtMaxRisk.Text) ? 0 : decimal.Parse(txtMaxRisk.Text);
+            Program.Settings.MaxShares = int.Parse(txtMaxShares.Text);
+            Program.Settings.UseBidAskOcoCalc = chkUseBidAskOcoCalc.Checked;
+            Program.Settings.DisableFirstTargetProfitDefault = chkDisableFirstTarget.Checked;
+            Program.Settings.OneRProfitPercenatage = int.Parse(txtOneRSharePct.Text);
+            Program.Settings.MoveLimitPriceOnFill = chkMoveLimitOnFill.Checked;
+            Program.Settings.ReduceStopOnClose = chkReduceStopOnClose.Checked;
+            Program.Settings.DefaultLimitOffset = string.IsNullOrEmpty(txtDefaultLimitOffset.Text) ? 0 : decimal.Parse(txtDefaultLimitOffset.Text);
+            Program.Settings.EnableMaxLossLimit = chkMaxLossLimit.Checked;
+            Program.Settings.MaxLossLimitInR = Program.Settings.EnableMaxLossLimit ? decimal.Parse(txtMaxLossLimit.Text) : 0;
+            Program.Settings.MinimumRisk = string.IsNullOrEmpty(txtMinRisk.Text) ? 0 : double.Parse(txtMinRisk.Text);
+            Program.Settings.SendAltPrtScrOnOpen = chkSendPrtScrOnOpen.Checked;
+            Program.Settings.ShowPnL = chkShowPnL.Checked;
+            Program.Settings.PreventRiskExceedMaxLoss = chkPreventExceedMaxLoss.Checked;
+            Program.Settings.AdjustRiskNotExceedMaxLoss = chkAdjustRiskForMaxLoss.Checked;
+            Program.Settings.AlwaysOnTop = chkAlwaysOnTop.Checked;
+            Program.Settings.CaptureScreenshotOnOpen = chkCaptureSSOnOpen.Checked;
 
-            Utility.SaveSettings(_settings);
+            Utility.SaveSettings(Program.Settings);
             this.Close();
         }
 
         private void UserOptionsForm_Load(object sender, EventArgs e)
         {
-            _settings = Utility.GetSettings();
-            if(_settings == null) _settings = new Settings();
+            Program.Settings = Utility.GetSettings();
+            if(Program.Settings == null) Program.Settings = new Settings();
 
-            chkTradeShares.Checked = _settings.TradeShares;
-            txtMaxRisk.Text = _settings.MaxRisk.ToString("#.##");
-            txtMaxShares.Text = _settings.MaxShares.ToString();
-            chkUseBidAskOcoCalc.Checked = _settings.UseBidAskOcoCalc;
-            chkDisableFirstTarget.Checked = _settings.DisableFirstTargetProfitDefault;
-            txtOneRSharePct.Text = _settings.OneRProfitPercenatage.ToString();
-            chkMoveLimitOnFill.Checked = _settings.MoveLimitPriceOnFill;
-            chkReduceStopOnClose.Checked = _settings.ReduceStopOnClose;
-            txtDefaultLimitOffset.Text = _settings.DefaultLimitOffset.ToString("#.##");
-            chkMaxLossLimit.Checked = _settings.EnableMaxLossLimit;
-            txtMaxLossLimit.Text = _settings.MaxLossLimitInR.ToString("#.##");
-            txtMinRisk.Text = _settings.MinimumRisk.ToString("#.##");
-            chkSendPrtScrOnOpen.Checked = _settings.SendAltPrtScrOnOpen;
-            chkShowPnL.Checked = _settings.ShowPnL;
-            chkPreventExceedMaxLoss.Checked = _settings.PreventRiskExceedMaxLoss;
-            chkAdjustRiskForMaxLoss.Checked = _settings.AdjustRiskNotExceedMaxLoss;
-            chkAlwaysOnTop.Checked = _settings.AlwaysOnTop;
-            chkCaptureSSOnOpen.Checked = _settings.CaptureScreenshotOnOpen;
+            chkTradeShares.Checked = Program.Settings.TradeShares;
+            txtMaxRisk.Text = Program.Settings.MaxRisk.ToString("#.##");
+            txtMaxShares.Text = Program.Settings.MaxShares.ToString();
+            chkUseBidAskOcoCalc.Checked = Program.Settings.UseBidAskOcoCalc;
+            chkDisableFirstTarget.Checked = Program.Settings.DisableFirstTargetProfitDefault;
+            txtOneRSharePct.Text = Program.Settings.OneRProfitPercenatage.ToString();
+            chkMoveLimitOnFill.Checked = Program.Settings.MoveLimitPriceOnFill;
+            chkReduceStopOnClose.Checked = Program.Settings.ReduceStopOnClose;
+            txtDefaultLimitOffset.Text = Program.Settings.DefaultLimitOffset.ToString("#.##");
+            chkMaxLossLimit.Checked = Program.Settings.EnableMaxLossLimit;
+            txtMaxLossLimit.Text = Program.Settings.MaxLossLimitInR.ToString("#.##");
+            txtMinRisk.Text = Program.Settings.MinimumRisk.ToString("#.##");
+            chkSendPrtScrOnOpen.Checked = Program.Settings.SendAltPrtScrOnOpen;
+            chkShowPnL.Checked = Program.Settings.ShowPnL;
+            chkPreventExceedMaxLoss.Checked = Program.Settings.PreventRiskExceedMaxLoss;
+            chkAdjustRiskForMaxLoss.Checked = Program.Settings.AdjustRiskNotExceedMaxLoss;
+            chkAlwaysOnTop.Checked = Program.Settings.AlwaysOnTop;
+            chkCaptureSSOnOpen.Checked = Program.Settings.CaptureScreenshotOnOpen;
 
         }
 

--- a/TdInterface/Program.cs
+++ b/TdInterface/Program.cs
@@ -10,6 +10,15 @@ namespace TdInterface
 {
     internal static class Program
     {
+        /// <summary>
+        /// TextWriterTraceListener for the application to use for debug / output logging.
+        /// </summary>
+        private static TextWriterTraceListener _textWriterTraceListener = null;
+
+        /// <summary>
+        /// AppVersion with Major.Minor.Build for display within the application and used to compare versions
+        /// </summary>
+        /// <example>3.1.17</example>
         public static string AppVersion
         {
             get
@@ -34,6 +43,16 @@ namespace TdInterface
             var services = new ServiceCollection();
             ConfigureServices(services);
 
+            // Setup debug trace listener for the application
+            string currentPath = Directory.GetCurrentDirectory();
+            string logFolder = Path.Combine(currentPath, "logs");
+            if (!Directory.Exists(logFolder))
+                Directory.CreateDirectory(logFolder);
+
+            _textWriterTraceListener = new TextWriterTraceListener($"{logFolder}\\{DateTime.Now.ToString("yyyyMMdd-HHmmss")}.log");
+            Trace.Listeners.Add(_textWriterTraceListener);
+
+
             using (ServiceProvider serviceProvider = services.BuildServiceProvider())
             {
                 var masterForm = serviceProvider.GetRequiredService<MasterForm>();
@@ -44,6 +63,17 @@ namespace TdInterface
         private static void ConfigureServices(ServiceCollection services)
         {
             services.AddSingleton<MasterForm>();
+        }
+        /// <summary>
+        /// Exit handler for the application
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private static void OnExit(object sender, EventArgs e)
+        {
+            _textWriterTraceListener.Flush();
+            _textWriterTraceListener.Close();
+            _textWriterTraceListener.Dispose();
         }
     }
 }

--- a/TdInterface/Program.cs
+++ b/TdInterface/Program.cs
@@ -15,6 +15,17 @@ namespace TdInterface
         /// </summary>
         private static TextWriterTraceListener _textWriterTraceListener = null;
 
+        private const string LOG_FOLDER = "logs";
+        private static string LOG_FILE = $"{DateTime.Now.ToString("yyyyMMdd-HHmmss")}.log";
+
+        public static string DebugLogFile
+        {
+            get
+            {
+                return Path.Combine(Directory.CreateDirectory(Path.Combine(Directory.GetCurrentDirectory(), LOG_FOLDER)).FullName, LOG_FILE);
+            }
+        }
+
         /// <summary>
         /// AppVersion with Major.Minor.Build for display within the application and used to compare versions
         /// </summary>
@@ -44,12 +55,7 @@ namespace TdInterface
             ConfigureServices(services);
 
             // Setup debug trace listener for the application
-            string currentPath = Directory.GetCurrentDirectory();
-            string logFolder = Path.Combine(currentPath, "logs");
-            if (!Directory.Exists(logFolder))
-                Directory.CreateDirectory(logFolder);
-
-            _textWriterTraceListener = new TextWriterTraceListener($"{logFolder}\\{DateTime.Now.ToString("yyyyMMdd-HHmmss")}.log");
+            _textWriterTraceListener = new TextWriterTraceListener(DebugLogFile);
             Trace.Listeners.Add(_textWriterTraceListener);
 
 

--- a/TdInterface/Program.cs
+++ b/TdInterface/Program.cs
@@ -18,6 +18,8 @@ namespace TdInterface
         private const string LOG_FOLDER = "logs";
         private static string LOG_FILE = $"{DateTime.Now.ToString("yyyyMMdd-HHmmss")}.log";
 
+        public static Settings Settings = new() { TradeShares = false, MaxRisk = 5M, MaxShares = 4, OneRProfitPercenatage = 25 };
+
         public static string DebugLogFile
         {
             get

--- a/TdInterface/Program.cs
+++ b/TdInterface/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using System.Windows.Forms;
 
@@ -8,26 +10,34 @@ namespace TdInterface
 {
     internal static class Program
     {
+        public static string AppVersion
+        {
+            get
+            {
+                var versionInfo = Assembly.GetExecutingAssembly().GetName().Version;
+                return $"{versionInfo.Major}.{versionInfo.Minor}.{versionInfo.Build}";
+            }
+        }
+
         /// <summary>
         ///  The main entry point for the application.
         /// </summary>
         [STAThread]
         static void Main()
         {
+            // Set application configuration
             Application.SetHighDpiMode(HighDpiMode.SystemAware);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+
             
             var services = new ServiceCollection();
             ConfigureServices(services);
 
             using (ServiceProvider serviceProvider = services.BuildServiceProvider())
             {
-                //var mainForm = serviceProvider.GetRequiredService<MainForm>();
-                //Application.Run(mainForm);
                 var masterForm = serviceProvider.GetRequiredService<MasterForm>();
                 Application.Run(masterForm);
-
             }
         }
 
@@ -35,12 +45,5 @@ namespace TdInterface
         {
             services.AddSingleton<MasterForm>();
         }
-
-        public static string GetAppVersion()
-        {
-            var versionInfo = Assembly.GetExecutingAssembly().GetName().Version;
-            return $"{versionInfo.Major}.{versionInfo.Minor}.{versionInfo.Build}";
-        }
-
     }
 }

--- a/TdInterface/Program.cs
+++ b/TdInterface/Program.cs
@@ -15,11 +15,15 @@ namespace TdInterface
         /// </summary>
         private static TextWriterTraceListener _textWriterTraceListener = null;
 
+        // Log Folder constants
         private const string LOG_FOLDER = "logs";
         private static string LOG_FILE = $"{DateTime.Now.ToString("yyyyMMdd-HHmmss")}.log";
 
         public static Settings Settings = new() { TradeShares = false, MaxRisk = 5M, MaxShares = 4, OneRProfitPercenatage = 25 };
 
+        /// <summary>
+        /// Path to the debug log file
+        /// </summary>
         public static string DebugLogFile
         {
             get

--- a/TdInterface/Program.cs
+++ b/TdInterface/Program.cs
@@ -64,6 +64,7 @@ namespace TdInterface
             _textWriterTraceListener = new TextWriterTraceListener(DebugLogFile);
             Trace.Listeners.Add(_textWriterTraceListener);
 
+            Settings = Utility.GetSettings();
 
             using (ServiceProvider serviceProvider = services.BuildServiceProvider())
             {

--- a/TdInterface/Tda/TDAOrderHelper.cs
+++ b/TdInterface/Tda/TDAOrderHelper.cs
@@ -176,6 +176,36 @@ namespace TdInterface.Tda
             return quantity;
         }
 
+        public static double CheckMaxRisk(double maxRisk, double dailyPnl, Settings settings)
+        {
+            if (!settings.TradeShares && settings.EnableMaxLossLimit)
+            {
+                var maxLoss = Convert.ToDouble(settings.MaxLossLimitInR * settings.MaxRisk) * -1;
+
+                if (dailyPnl < maxLoss)
+                {
+                    throw new DailyLossExceededException("You have exceeded your daily loss limit");
+                }
+
+                if (settings.PreventRiskExceedMaxLoss)
+                {
+                    if ((Convert.ToDouble(dailyPnl) - maxRisk) < maxLoss)
+                    {
+                        if (settings.AdjustRiskNotExceedMaxLoss)
+                        {
+                            maxRisk = Math.Abs(maxLoss - dailyPnl);
+                        }
+                        else
+                        {
+                            throw new DailyLossExceededException("This trade will put you over your daily loss limit");
+                        }
+                    }
+                }
+            }
+
+            return maxRisk;
+        }
+
         private static Order GetParentOrder(Order order, Order child)
         {
             if (order == child)

--- a/TdInterface/Tda/TdHelper.cs
+++ b/TdInterface/Tda/TdHelper.cs
@@ -18,7 +18,6 @@ namespace TdInterface.Tda
         public const string ACCESSTOKENCONTAINER = "tda-accesstokencontainer.json";
         public static HttpClient _httpClient = new HttpClient();
         public static Uri BaseUri = new Uri("https://api.tdameritrade.com");
-        public Utility _utility = new Utility();
 
 
         public const string routeGetToken = "v1/oauth2/token";
@@ -37,10 +36,9 @@ namespace TdInterface.Tda
         private Dictionary<string, TdInterface.Model.StockQuote> _stockQuotes = new();
 
         public TdHelper() { }
-        public TdHelper(HttpClient httpClient, Utility utility) 
+        public TdHelper(HttpClient httpClient) 
         { 
             _httpClient = httpClient; 
-            _utility = utility;
         }
 
 
@@ -67,7 +65,7 @@ namespace TdInterface.Tda
         public async Task<AccessTokenContainer> GetAccessToken(string authToken)
         {
 
-            var accountInfo = _utility.GetAccountInfo();
+            var accountInfo = Utility.GetAccountInfo();
 
             Utility.SplitTdaConsumerKey(accountInfo.TdaConsumerKey, out string consumerKey, out string redirectUri);
 
@@ -101,7 +99,7 @@ namespace TdInterface.Tda
         {
             try
             {
-                var accountInfo = _utility.GetAccountInfo();
+                var accountInfo = Utility.GetAccountInfo();
 
                 Utility.SplitTdaConsumerKey(accountInfo.TdaConsumerKey, out string consumerKey, out string redirectUri);
 

--- a/TdInterface/Tda/TdHelper.cs
+++ b/TdInterface/Tda/TdHelper.cs
@@ -34,11 +34,12 @@ namespace TdInterface.Tda
 
         private static Securitiesaccount _securitiesaccount;
         private Dictionary<string, TdInterface.Model.StockQuote> _stockQuotes = new();
+        private AccessTokenContainer accessTokenContainer;
 
         public TdHelper() { }
-        public TdHelper(HttpClient httpClient) 
-        { 
-            _httpClient = httpClient; 
+        public TdHelper(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
         }
 
 
@@ -54,7 +55,22 @@ namespace TdInterface.Tda
             }
         }
 
-        public AccessTokenContainer AccessTokenContainer { get; set; }
+        public AccessTokenContainer AccessTokenContainer
+        {
+            get
+            {
+                if (accessTokenContainer== null)
+                {
+                    accessTokenContainer = Utility.GetAccessTokenContainer(ACCESSTOKENCONTAINER);
+                }
+                return accessTokenContainer;
+            }
+            set
+            {
+                Debug.WriteLine("***********************ACCESSTOKENCONTAINER BEING SET");
+                accessTokenContainer = value;
+            }
+        }
 
 
         /// <summary>
@@ -88,7 +104,7 @@ namespace TdInterface.Tda
 
             AccessTokenContainer = Utility.DeserializeJsonFromStream<AccessTokenContainer>(await response.Content.ReadAsStreamAsync());
             AccessTokenContainer.TokenSystem = AccessTokenContainer.EnumTokenSystem.TDA;
-            
+
             //Write the access token container, this should ahve the refresh token
             Utility.SaveAccessTokenContainer(ACCESSTOKENCONTAINER, AccessTokenContainer);
 
@@ -127,7 +143,7 @@ namespace TdInterface.Tda
                 AccessTokenContainer = newAccessTokenContainer;
                 return AccessTokenContainer;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Debug.WriteLine(ex.Message);
                 throw;
@@ -187,7 +203,7 @@ namespace TdInterface.Tda
             var response = await _httpClient.SendAsync(request);
             var candleList = Utility.DeserializeJsonFromStream<CandleList>(await response.Content.ReadAsStreamAsync());
 
-            foreach(var candle in candleList.candles)
+            foreach (var candle in candleList.candles)
             {
                 Debug.WriteLine($"{candle.DateTime},{candle.open},{candle.close},{candle.high},{candle.low},{candle.volume}");
             }
@@ -201,15 +217,15 @@ namespace TdInterface.Tda
             {
                 Method = HttpMethod.Post,
                 Content = new StringContent(JsonConvert.SerializeObject(order), Encoding.UTF8, "application/json")
-             };
+            };
 
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", AccessTokenContainer.AccessToken);
 
             var response = await _httpClient.SendAsync(request).ConfigureAwait(true);
-            if(response.StatusCode != System.Net.HttpStatusCode.Created)
+            if (response.StatusCode != System.Net.HttpStatusCode.Created)
             {
                 Debug.Write(order);
-                throw new Exception($"Error Creating Order { await response.Content.ReadAsStringAsync()} ");
+                throw new Exception($"Error Creating Order {await response.Content.ReadAsStringAsync()} ");
             };
 
             var orderNumberString = response.Headers.Location.PathAndQuery.Substring(response.Headers.Location.PathAndQuery.LastIndexOf("/") + 1);
@@ -231,7 +247,7 @@ namespace TdInterface.Tda
 
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", AccessTokenContainer.AccessToken);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
-            
+
             var response = await _httpClient.SendAsync(request).ConfigureAwait(true);
             if (response.StatusCode != System.Net.HttpStatusCode.Created)
             {
@@ -335,7 +351,7 @@ namespace TdInterface.Tda
 
         public TdInterface.Model.StockQuote GetStockQuote(string symbol)
         {
-            if(!_stockQuotes.ContainsKey(symbol)) { return null; }
+            if (!_stockQuotes.ContainsKey(symbol)) { return null; }
 
             return _stockQuotes[symbol];
         }

--- a/TdInterface/TradeStation/TradeStationHelper.cs
+++ b/TdInterface/TradeStation/TradeStationHelper.cs
@@ -17,6 +17,7 @@ namespace TdInterface.TradeStation
     public class TradeStationHelper : IHelper
     {
         public const string ACCESSTOKENCONTAINER = "ts-accesstokencontainer.json";
+        private const string BASE_SIM_URI = "https://sim-api.tradestation.com/";
 
         public static HttpClient _httpClient = new HttpClient();
         public static Uri BaseUri = new Uri("https://api.tradestation.com/");
@@ -35,6 +36,8 @@ namespace TdInterface.TradeStation
         private Dictionary<string, TdInterface.Model.StockQuote> _stockQuotes = new();
 
         private static Securitiesaccount _securitiesaccount;
+        private AccessTokenContainer accessTokenContainer;
+
 
         public Securitiesaccount Securitiesaccount
         {
@@ -48,16 +51,29 @@ namespace TdInterface.TradeStation
             }
         }
 
-        public AccessTokenContainer AccessTokenContainer { get; set; }
-
-        public TradeStationHelper(string clientId, string clientSecret) 
+        public AccessTokenContainer AccessTokenContainer
         { 
+            get
+            {
+                if (accessTokenContainer == null)
+                {
+                    accessTokenContainer = Utility.GetAccessTokenContainer(ACCESSTOKENCONTAINER);
+                }
+                return accessTokenContainer;
+            }
+            set
+            {
+                Debug.WriteLine("***********************ACCESSTOKENCONTAINER BEING SET");
+                accessTokenContainer = value;
+            }
+        }
+
+        public TradeStationHelper(string clientId, string clientSecret, bool useSim)
+        {
+            if (useSim)
+                BaseUri = new Uri(BASE_SIM_URI);
             _clientId = clientId;
             _clientSecret = clientSecret;
-        }
-        public TradeStationHelper(string baseUri, string clientId, string clientSecret) : this(clientId, clientSecret)
-        {
-            BaseUri = new Uri(baseUri);
         }
 
         /// <summary>

--- a/TdInterface/TradeStation/TradeStationHelper.cs
+++ b/TdInterface/TradeStation/TradeStationHelper.cs
@@ -303,7 +303,7 @@ namespace TdInterface.TradeStation
 
             //var orderNumber = ulong.Parse(o.OrderID);
 
-            ulong orderNumber = 0l;
+            ulong orderNumber = 0L;
             return orderNumber;
         }
 

--- a/TdInterface/TradeStation/TradeStationHelper.cs
+++ b/TdInterface/TradeStation/TradeStationHelper.cs
@@ -451,7 +451,7 @@ namespace TdInterface.TradeStation
                 }
                 catch(Exception ex)
                 {
-                    Console.WriteLine();
+                    Debug.WriteLine(ex.Message);
                 }
             }
 

--- a/TdInterface/Utility.cs
+++ b/TdInterface/Utility.cs
@@ -19,7 +19,7 @@ using TdInterface.Properties;
 
 namespace TdInterface
 {
-    public class Utility
+    public static class Utility
     {
         private static string SettingsFile = "Settings.json";
         private static string AccountInfoFile = "AccountInfo.json";
@@ -84,7 +84,7 @@ namespace TdInterface
             File.WriteAllBytes(AccountInfoFile, encrypted);
         }
 
-        public virtual AccountInfo GetAccountInfo()
+        public static AccountInfo GetAccountInfo()
         {
             try
             {

--- a/TdInterface/Utility.cs
+++ b/TdInterface/Utility.cs
@@ -223,7 +223,7 @@ namespace TdInterface
                     if (tagName != null)
                     {
                         var latestVersion = new Version(jsonNode["tag_name"].ToString());
-                        var currentVersion = new Version(Program.GetAppVersion());
+                        var currentVersion = new Version(Program.AppVersion);
                         return latestVersion > currentVersion;
                     }
                 }

--- a/TdInterfaceTests/MainFormTests.cs
+++ b/TdInterfaceTests/MainFormTests.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using TdInterface.Tda;
 using TdInterface.Tda.Model;
 using TdInterface.TradeStation.Model;
+using Microsoft.VisualStudio.TestPlatform.TestHost;
 
 namespace TdInterface.Tests
 {
@@ -42,7 +43,7 @@ namespace TdInterface.Tests
             var currentBalances = new Currentbalances { liquidationValue = 2484 };
             var securitiesAccount = new Securitiesaccount { currentBalances = currentBalances, initialBalances = initialBalances };
 
-            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, 149.92, false, 5, securitiesAccount.DailyPnL, false);
+            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, 149.92, false, 5, securitiesAccount.DailyPnL, false, settings);
         }
 
         [TestMethod()]
@@ -61,7 +62,7 @@ namespace TdInterface.Tests
             var currentBalances = new Currentbalances { liquidationValue = 2489 };
             var securitiesAccount = new Securitiesaccount { currentBalances = currentBalances, initialBalances = initialBalances };
 
-            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, 149.92, false, 5, securitiesAccount.DailyPnL, false);
+            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, 149.92, false, 5, securitiesAccount.DailyPnL, false, settings);
         }
 
         [TestMethod()]
@@ -87,7 +88,7 @@ namespace TdInterface.Tests
 
             var expectedShares = Convert.ToInt32(((settings.MaxLossLimitInR * settings.MaxRisk) + Convert.ToDecimal(securitiesAccount.DailyPnL)) / Convert.ToDecimal(expectedRiskPerShare));
 
-            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, stop, false, 5, securitiesAccount.DailyPnL, false);
+            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, stop, false, 5, securitiesAccount.DailyPnL, false, settings);
 
             Assert.AreEqual(expectedShares, actual.orderLegCollection[0].quantity);
         }
@@ -104,7 +105,7 @@ namespace TdInterface.Tests
                 MaxLossLimitInR = 3,
                 AdjustRiskNotExceedMaxLoss = false,
             };
-            var actual = MainForm.CheckMaxRisk(expectedMaxRisk, dailyPnl);
+            var actual = TDAOrderHelper.CheckMaxRisk(expectedMaxRisk, dailyPnl, settings);
 
             Assert.AreEqual(expectedMaxRisk, actual);
         }
@@ -122,7 +123,7 @@ namespace TdInterface.Tests
                 MaxLossLimitInR = 3,
                 AdjustRiskNotExceedMaxLoss = false,
             };
-            var actual = MainForm.CheckMaxRisk(expectedMaxRisk, dailyPnl);
+           var actual = TDAOrderHelper.CheckMaxRisk(expectedMaxRisk, dailyPnl, settings);
         }
 
         [TestMethod()]

--- a/TdInterfaceTests/MainFormTests.cs
+++ b/TdInterfaceTests/MainFormTests.cs
@@ -42,7 +42,7 @@ namespace TdInterface.Tests
             var currentBalances = new Currentbalances { liquidationValue = 2484 };
             var securitiesAccount = new Securitiesaccount { currentBalances = currentBalances, initialBalances = initialBalances };
 
-            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, 149.92, false, 5, securitiesAccount.DailyPnL, false, settings);
+            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, 149.92, false, 5, securitiesAccount.DailyPnL, false);
         }
 
         [TestMethod()]
@@ -61,7 +61,7 @@ namespace TdInterface.Tests
             var currentBalances = new Currentbalances { liquidationValue = 2489 };
             var securitiesAccount = new Securitiesaccount { currentBalances = currentBalances, initialBalances = initialBalances };
 
-            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, 149.92, false, 5, securitiesAccount.DailyPnL, false, settings);
+            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, 149.92, false, 5, securitiesAccount.DailyPnL, false);
         }
 
         [TestMethod()]
@@ -87,7 +87,7 @@ namespace TdInterface.Tests
 
             var expectedShares = Convert.ToInt32(((settings.MaxLossLimitInR * settings.MaxRisk) + Convert.ToDecimal(securitiesAccount.DailyPnL)) / Convert.ToDecimal(expectedRiskPerShare));
 
-            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, stop, false, 5, securitiesAccount.DailyPnL, false, settings);
+            var actual = MainForm.CreateGenericTriggerOcoOrder(quote, "MARKET", "AAPL", TDAOrderHelper.BUY, 0.0, stop, false, 5, securitiesAccount.DailyPnL, false);
 
             Assert.AreEqual(expectedShares, actual.orderLegCollection[0].quantity);
         }
@@ -104,7 +104,7 @@ namespace TdInterface.Tests
                 MaxLossLimitInR = 3,
                 AdjustRiskNotExceedMaxLoss = false,
             };
-            var actual = MainForm.CheckMaxRisk(expectedMaxRisk, dailyPnl, settings);
+            var actual = MainForm.CheckMaxRisk(expectedMaxRisk, dailyPnl);
 
             Assert.AreEqual(expectedMaxRisk, actual);
         }
@@ -122,7 +122,7 @@ namespace TdInterface.Tests
                 MaxLossLimitInR = 3,
                 AdjustRiskNotExceedMaxLoss = false,
             };
-            var actual = MainForm.CheckMaxRisk(expectedMaxRisk, dailyPnl, settings);
+            var actual = MainForm.CheckMaxRisk(expectedMaxRisk, dailyPnl);
         }
 
         [TestMethod()]

--- a/TdInterfaceTests/Tda/TdHelperTests.cs
+++ b/TdInterfaceTests/Tda/TdHelperTests.cs
@@ -14,19 +14,18 @@ namespace TdInterface.Tda.Tests
     [TestClass()]
     public class TdHelperTests
     {
-        private static Mock<Utility> _mockUtility;
 
         [ClassInitialize]
         public static void Init(TestContext context)
         {
-            var expectedAccountInfo = new AccountInfo
-            {
-                TdaConsumerKey = "tdakey",
-                UseTdaEquity = true
-            };
+            //var expectedAccountInfo = new AccountInfo
+            //{
+            //    TdaConsumerKey = "tdakey",
+            //    UseTdaEquity = true
+            //};
 
-            var _mockUtility = new Mock<Utility>();
-            _mockUtility.Setup(s => s.GetAccountInfo()).Returns(expectedAccountInfo);
+            //var _mockUtility = new Mock<Utility>();
+            //_mockUtility.Setup(s => s.GetAccountInfo()).Returns(expectedAccountInfo);
 
         }
 

--- a/TdInterfaceTests/TradeStation/TradeStationHelperTests.cs
+++ b/TdInterfaceTests/TradeStation/TradeStationHelperTests.cs
@@ -23,7 +23,7 @@ namespace TdInterface.TradeStation.Tests
                 lastPrice = 139.98
             };
 
-            var helper = new TradeStationHelper("", "");
+            var helper = new TradeStationHelper("", "", false);
             var actual = helper.SetStockQuote(expectedAaplQuote);
 
             Assert.AreEqual(expectedAaplQuote.lastPrice, actual.lastPrice);
@@ -43,7 +43,7 @@ namespace TdInterface.TradeStation.Tests
                 lastPrice = 139.98
             };
 
-            var helper = new TradeStationHelper("", "");
+            var helper = new TradeStationHelper("", "", false);
             var _ = helper.SetStockQuote(initialAaplQuote);
 
             var incrementalQuote = new TdInterface.Model.StockQuote
@@ -72,7 +72,7 @@ namespace TdInterface.TradeStation.Tests
                 lastPrice = 139.98
             };
 
-            var helper = new TradeStationHelper("", "");
+            var helper = new TradeStationHelper("", "", false);
 
             var _ = helper.SetStockQuote(expectedAaplQuote);
 


### PR DESCRIPTION
Moved mostly everything out of Master Form. Want to get this merged / pause here b4 next big change.

This moved as much as possible to OrderHelper and Programs out of MasterForm. Anything that was 'program' wide, and not form specific, moved to Program. Anything that was calculating something, moved it to OrderHelper.

Updated Utility to be static, so we don't have to create an instance b4 using.

Next change will be to move Login out, but want to use this opportunity to refactor IHelper to handle Login, and remove need to have three helpers in master form.

IHelper will eventually become IBrokerage or something similar, and will have account info, etc. so that login/orders can all be handled with simple broker.ExecuteAction (login, order, etc.)