### PR TITLE
Screenshots and Log cleanup

### DIFF
--- a/TdInterface/Forms/AccountInfoForm.Designer.cs
+++ b/TdInterface/Forms/AccountInfoForm.Designer.cs
@@ -206,14 +206,16 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 19F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(304, 484);
+            this.ClientSize = new System.Drawing.Size(304, 499);
             this.Controls.Add(this.textBox1);
             this.Controls.Add(this.btnClearCreds);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnSave);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Margin = new System.Windows.Forms.Padding(3);
+            this.MaximizeBox = false;
             this.Name = "AccountInfoForm";
             this.Text = "EZTM Account Settings";
             this.Load += new System.EventHandler(this.AccountInfoForm_Load);

--- a/TdInterface/Forms/FurtureCalcForm.Designer.cs
+++ b/TdInterface/Forms/FurtureCalcForm.Designer.cs
@@ -243,6 +243,8 @@
             this.Controls.Add(this.label1);
             this.Controls.Add(this.lblSymbol);
             this.Controls.Add(this.txtSymbol);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
             this.Name = "FurtureCalcForm";
             this.Text = "Futures Calculator";
             this.ResumeLayout(false);

--- a/TdInterface/Forms/MainForm.Designer.cs
+++ b/TdInterface/Forms/MainForm.Designer.cs
@@ -85,6 +85,7 @@ namespace TdInterface
             this.btnExit10 = new System.Windows.Forms.Button();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.lblVersion = new System.Windows.Forms.Label();
+            this.btnScreenshot = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.SuspendLayout();
@@ -648,9 +649,20 @@ namespace TdInterface
             this.lblVersion.Text = "Version";
             this.lblVersion.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
+            // btnScreenshot
+            // 
+            this.btnScreenshot.Location = new System.Drawing.Point(344, 453);
+            this.btnScreenshot.Name = "btnScreenshot";
+            this.btnScreenshot.Size = new System.Drawing.Size(44, 26);
+            this.btnScreenshot.TabIndex = 40;
+            this.btnScreenshot.Text = "🖼️";
+            this.btnScreenshot.UseVisualStyleBackColor = true;
+            this.btnScreenshot.Click += new System.EventHandler(this.btnScreenshot_Click);
+            // 
             // MainForm
             // 
             this.ClientSize = new System.Drawing.Size(694, 496);
+            this.Controls.Add(this.btnScreenshot);
             this.Controls.Add(this.lblVersion);
             this.Controls.Add(this.txtMoveStop);
             this.Controls.Add(this.label11);
@@ -691,12 +703,9 @@ namespace TdInterface
             this.Controls.Add(this.label1);
             this.Controls.Add(this.lblSymbol);
             this.Controls.Add(this.txtSymbol);
-            this.Font = new System.Drawing.Font("Segoe UI", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.KeyPreview = true;
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.MaximizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(710, 535);
             this.Name = "MainForm";
             this.Text = "EZTM - EZ Trade Manager";
             this.Load += new System.EventHandler(this.MainForm_Load);
@@ -765,6 +774,7 @@ namespace TdInterface
         private System.Windows.Forms.Button btnExit10;
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.Label lblVersion;
+        private System.Windows.Forms.Button btnScreenshot;
     }
 }
 

--- a/TdInterface/Forms/MainForm.cs
+++ b/TdInterface/Forms/MainForm.cs
@@ -142,7 +142,7 @@ namespace TdInterface
 
                 // Capture Screenshots if requested
                 if (Program.Settings.SendAltPrtScrOnOpen) { InputSender.PrintScreen(); }
-                if (Program.Settings.CaptureScreenshotOnOpen) { _ = Task.Run(() => Utility.CaptureScreen($"{txtSymbol.Text}_createOrder")); }
+                if (Program.Settings.CaptureScreenshotOnOpen) { _ = Task.Run(() => Utility.CaptureScreen(txtSymbol.Text)); }
             }
             catch (Exception ex)
             {
@@ -618,7 +618,7 @@ namespace TdInterface
                     Debug.WriteLine($"HandleOrderFilled: initial orders {JsonConvert.SerializeObject(_initialOrders)}");
 
                     // Capture a screenshot after 1 second, as it takes time for ToS to actually show the orders on the screen.... may need to tweak this.
-                    if (Program.Settings.CaptureScreenshotOnOpen) { _ = Task.Run(() => { Task.Delay(1000); Utility.CaptureScreen($"{txtSymbol.Text}_OrderFilled"); }) ; }
+                    if (Program.Settings.CaptureScreenshotOnOpen) { _ = Task.Run(() => { Task.Delay(1000); Utility.CaptureScreen(txtSymbol.Text); }); };
 
                     //check to see if this is the initial Limit order, if it is, set the stop to BE.
                     if (_initialLimitOrder != null)
@@ -1089,5 +1089,10 @@ namespace TdInterface
         }
 
         #endregion
+
+        private void btnScreenshot_Click(object sender, EventArgs e)
+        {
+            Utility.CaptureScreen(txtSymbol.Text);
+        }
     }
 }

--- a/TdInterface/Forms/MainForm.cs
+++ b/TdInterface/Forms/MainForm.cs
@@ -142,7 +142,7 @@ namespace TdInterface
 
                 // Capture Screenshots if requested
                 if (Program.Settings.SendAltPrtScrOnOpen) { InputSender.PrintScreen(); }
-                if (Program.Settings.CaptureScreenshotOnOpen) { _ = Task.Run(() => Utility.CaptureScreen(txtSymbol.Text)); }
+                if (Program.Settings.CaptureScreenshotOnOpen) { _ = Task.Run(() => Utility.CaptureScreen($"{txtSymbol.Text}_createOrder")); }
             }
             catch (Exception ex)
             {
@@ -617,6 +617,8 @@ namespace TdInterface
                     Debug.WriteLine($"HandleOrderFilled: symbol {symbol}");
                     Debug.WriteLine($"HandleOrderFilled: initial orders {JsonConvert.SerializeObject(_initialOrders)}");
 
+                    // Capture a screenshot after 1 second, as it takes time for ToS to actually show the orders on the screen.... may need to tweak this.
+                    if (Program.Settings.CaptureScreenshotOnOpen) { _ = Task.Run(() => { Task.Delay(1000); Utility.CaptureScreen($"{txtSymbol.Text}_OrderFilled"); }) ; }
 
                     //check to see if this is the initial Limit order, if it is, set the stop to BE.
                     if (_initialLimitOrder != null)

--- a/TdInterface/Forms/MasterForm.Designer.cs
+++ b/TdInterface/Forms/MasterForm.Designer.cs
@@ -34,6 +34,7 @@
             this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.accountSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.checkForUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.btnFuturesCalc = new System.Windows.Forms.Button();
             this.btnAMZN = new System.Windows.Forms.Button();
@@ -55,7 +56,6 @@
             this.lblTradeLine = new System.Windows.Forms.Label();
             this.lblTrade = new System.Windows.Forms.Label();
             this.btnScreenshots = new System.Windows.Forms.Button();
-            this.checkForUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -89,21 +89,28 @@
             // settingsToolStripMenuItem
             // 
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.settingsToolStripMenuItem.Text = "Settings";
             this.settingsToolStripMenuItem.Click += new System.EventHandler(this.settingsToolStripMenuItem_Click);
             // 
             // accountSettingsToolStripMenuItem
             // 
             this.accountSettingsToolStripMenuItem.Name = "accountSettingsToolStripMenuItem";
-            this.accountSettingsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.accountSettingsToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.accountSettingsToolStripMenuItem.Text = "Account Settings";
             this.accountSettingsToolStripMenuItem.Click += new System.EventHandler(this.accountSettingsToolStripMenuItem_Click);
+            // 
+            // checkForUpdateToolStripMenuItem
+            // 
+            this.checkForUpdateToolStripMenuItem.Name = "checkForUpdateToolStripMenuItem";
+            this.checkForUpdateToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+            this.checkForUpdateToolStripMenuItem.Text = "Check For Update";
+            this.checkForUpdateToolStripMenuItem.Click += new System.EventHandler(this.checkForUpdateToolStripMenuItem_Click);
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
@@ -318,18 +325,11 @@
             this.btnScreenshots.UseVisualStyleBackColor = true;
             this.btnScreenshots.Click += new System.EventHandler(this.btnScreenshots_Click);
             // 
-            // checkForUpdateToolStripMenuItem
-            // 
-            this.checkForUpdateToolStripMenuItem.Name = "checkForUpdateToolStripMenuItem";
-            this.checkForUpdateToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.checkForUpdateToolStripMenuItem.Text = "Check For Update";
-            this.checkForUpdateToolStripMenuItem.Click += new System.EventHandler(this.checkForUpdateToolStripMenuItem_Click);
-            // 
             // MasterForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 19F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(301, 299);
+            this.ClientSize = new System.Drawing.Size(301, 309);
             this.Controls.Add(this.btnScreenshots);
             this.Controls.Add(this.lblTradeLine);
             this.Controls.Add(this.lblTrade);
@@ -354,6 +354,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MainMenuStrip = this.menuStrip1;
             this.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.MaximizeBox = false;
             this.Name = "MasterForm";
             this.Text = "EZTM";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MasterForm_FormClosing);

--- a/TdInterface/Forms/UserOptionsForm.Designer.cs
+++ b/TdInterface/Forms/UserOptionsForm.Designer.cs
@@ -113,7 +113,7 @@ namespace TdInterface
             // 
             // btnSave
             // 
-            this.btnSave.Location = new System.Drawing.Point(888, 417);
+            this.btnSave.Location = new System.Drawing.Point(862, 394);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(94, 28);
             this.btnSave.TabIndex = 7;
@@ -123,7 +123,7 @@ namespace TdInterface
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(788, 417);
+            this.btnCancel.Location = new System.Drawing.Point(758, 394);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(94, 28);
             this.btnCancel.TabIndex = 8;
@@ -367,7 +367,9 @@ namespace TdInterface
             this.Controls.Add(this.label1);
             this.Controls.Add(this.chkTradeShares);
             this.Controls.Add(this.lblTradeShares);
-            this.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Margin = new System.Windows.Forms.Padding(3);
+            this.MaximizeBox = false;
             this.Name = "UserOptionsForm";
             this.Text = "EZTM Settings";
             this.Load += new System.EventHandler(this.UserOptionsForm_Load);

--- a/TdInterface/Program.cs
+++ b/TdInterface/Program.cs
@@ -20,7 +20,7 @@ namespace TdInterface
         private const string LOG_FOLDER = "logs";
         private static string LOG_FILE = $"{DateTime.Now.ToString("yyyyMMdd-HHmmss")}.log";
 
-        public static Settings Settings = new() { TradeShares = false, MaxRisk = 5M, MaxShares = 4, OneRProfitPercenatage = 25 };
+        public static Settings Settings;
 
         /// <summary>
         /// Path to the debug log file

--- a/TdInterface/Program.cs
+++ b/TdInterface/Program.cs
@@ -53,10 +53,9 @@ namespace TdInterface
         static void Main()
         {
             // Set application configuration
-            Application.SetHighDpiMode(HighDpiMode.SystemAware);
+            Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-
             
             var services = new ServiceCollection();
             ConfigureServices(services);

--- a/TdInterface/Utility.cs
+++ b/TdInterface/Utility.cs
@@ -66,8 +66,16 @@ namespace TdInterface
         {
             try
             {
-                var settinngsAsString = File.ReadAllText(SettingsFile);
-                return JsonConvert.DeserializeObject<Settings>(settinngsAsString);
+                if (File.Exists(SettingsFile))
+                {
+                    var settinngsAsString = File.ReadAllText(SettingsFile);
+                    return JsonConvert.DeserializeObject<Settings>(settinngsAsString);
+                }
+                else
+                {
+                    return new() { TradeShares = false, MaxRisk = 5M, MaxShares = 4, OneRProfitPercenatage = 25 };
+
+                }
             }
             catch
             {

--- a/TdInterface/Utility.cs
+++ b/TdInterface/Utility.cs
@@ -139,10 +139,10 @@ namespace TdInterface
 
                 //Creating a New Graphics Object pointing to bitmap to capture to
                 Graphics captureGraphics = Graphics.FromImage(captureBitmap);
-                
+
                 //Copying Image from The Screen
                 captureGraphics.CopyFromScreen(captureRectangle.Left, captureRectangle.Top, 0, 0, captureRectangle.Size);
-                
+
                 //Save the screenshot
                 captureBitmap.Save(Path.Combine(ScreenshotPath(ticker), $"{DateTime.Now.ToString("yyyyMMdd-HHmmss")}_{ticker}.png"), ImageFormat.Png);
             }


### PR DESCRIPTION
Fixed an issue where exit handler wasn't called for the Program to flush traces

Added a little code to delete logs after 7 days.... as they start to take up a LOT of space. (Some days were ~1g in total for me)

Added a screenshot button to the MainForm so you can capture a screenshot at anytime.... handy for testing, and maybe for using.. :)

Fixed an issue where screenshots were not accounting for DPI scaling on different monitors. This required a change to support  PerMonitor DPI Mode. Please test this on your displays

Updated all windows to have a bit more size when moved as part of scaling...

Updated all windows to be fixed single - not sizeable/maximized.